### PR TITLE
feat: implement upload-raw and download-raw commands with progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 ./zstore upload /path/to/file.txt zs://my-bucket/path/file.txt --data-shards 6 --parity-shards 3
 
 # Upload without erasure coding (raw file)
-./zstore upload /path/to/file.txt zs://my-bucket/path/file.txt --no-erasure-coding
+./zstore upload-raw /path/to/file.txt s3://my-bucket/path/file.txt
+
+# Upload raw file in quiet mode
+./zstore upload-raw /path/to/file.txt s3://my-bucket/path/file.txt --quiet
 
 # Upload in quiet mode (suppress progress bars)
 ./zstore upload /path/to/file.txt zs://my-bucket/path/file.txt --quiet
@@ -67,6 +70,12 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 # Download with custom concurrency
 ./zstore download zs://my-bucket/path/file.txt /path/to/output.txt --concurrency 5
+
+# Download without erasure coding (raw file)
+./zstore download-raw s3://my-bucket/path/file.txt /path/to/output.txt
+
+# Download raw file in quiet mode
+./zstore download-raw s3://my-bucket/path/file.txt /path/to/output.txt --quiet
 
 # Download in quiet mode
 ./zstore download zs://my-bucket/path/file.txt /path/to/output.txt --quiet
@@ -87,11 +96,13 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 - `--data-shards`: Number of data shards for erasure coding (default: 4)
 - `--parity-shards`: Number of parity shards for erasure coding (default: 2)
 - `--concurrency`: Number of concurrent shard uploads (default: 3)
-- `--no-erasure-coding`: Upload file directly without erasure coding
 
 ### Download Options
 - `--concurrency`: Number of concurrent shard downloads (default: 3)
-- `--no-erasure-coding`: Download file directly without erasure coding reconstruction
+
+### Raw Operations
+- `upload-raw`: Upload files directly to S3 without erasure coding (uses s3:// URLs, supports --quiet)
+- `download-raw`: Download files directly from S3 without erasure coding (uses s3:// URLs, supports --quiet)
 
 ## Configuration
 

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -21,9 +21,22 @@ func parseZsURL(zsURL string) (string, error) {
 	return strings.TrimPrefix(zsURL, "zs://"), nil
 }
 
+// parseS3URL parses an s3:// URL and returns the bucket and key
+func parseS3URL(s3URL string) (string, string, error) {
+	if !strings.HasPrefix(s3URL, "s3://") {
+		return "", "", fmt.Errorf("URL must start with s3://")
+	}
+	path := strings.TrimPrefix(s3URL, "s3://")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) < 2 {
+		return parts[0], "", nil
+	}
+	return parts[0], parts[1], nil
+}
+
 var uploadCmd = &cobra.Command{
 	Use:   "upload [file-path] [zs://bucket/prefix/object]",
-	Short: "Upload a file to cloud storage (destination optional - uses filename if not specified)",
+	Short: "Upload a file with erasure coding (destination optional - uses filename if not specified)",
 	Args:  cobra.RangeArgs(1, 2),
 	Run: func(cmd *cobra.Command, args []string) {
 		filePath := args[0]
@@ -55,16 +68,10 @@ var uploadCmd = &cobra.Command{
 		defer file.Close()
 
 		quiet, _ := cmd.Flags().GetBool("quiet")
-		noErasureCoding, _ := cmd.Flags().GetBool("no-erasure-coding")
-
-		if noErasureCoding {
-			err = rawFileService.UploadFileRaw(context.Background(), key, file, quiet)
-		} else {
-			dataShards, _ := cmd.Flags().GetInt("data-shards")
-			parityShards, _ := cmd.Flags().GetInt("parity-shards")
-			concurrency, _ := cmd.Flags().GetInt("concurrency")
-			err = fileService.UploadFile(context.Background(), key, file, quiet, dataShards, parityShards, concurrency)
-		}
+		dataShards, _ := cmd.Flags().GetInt("data-shards")
+		parityShards, _ := cmd.Flags().GetInt("parity-shards")
+		concurrency, _ := cmd.Flags().GetInt("concurrency")
+		err = fileService.UploadFile(context.Background(), key, file, quiet, dataShards, parityShards, concurrency)
 		if err != nil {
 			fmt.Printf("Error uploading file: %v\n", err)
 			return
@@ -73,9 +80,52 @@ var uploadCmd = &cobra.Command{
 	},
 }
 
+var uploadRawCmd = &cobra.Command{
+	Use:   "upload-raw [file-path] [s3://bucket/prefix/object]",
+	Short: "Upload a file directly without erasure coding (destination optional - uses filename if not specified)",
+	Args:  cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		filePath := args[0]
+		
+		// Auto-detect destination if not provided or if destination ends with /
+		var bucket, key string
+		if len(args) == 2 {
+			// Parse s3:// URL to extract bucket and key
+			var err error
+			bucket, key, err = parseS3URL(args[1])
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+			// If key ends with / or is empty, append filename
+			if key == "" || strings.HasSuffix(key, "/") {
+				key = key + filepath.Base(filePath)
+			}
+		} else {
+			fmt.Printf("Error: s3:// destination is required for raw uploads\n")
+			return
+		}
+
+		file, err := os.Open(filePath)
+		if err != nil {
+			fmt.Printf("Error opening file: %v\n", err)
+			return
+		}
+		defer file.Close()
+
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		err = rawFileService.UploadFileRaw(context.Background(), bucket, key, file, quiet)
+		if err != nil {
+			fmt.Printf("Error uploading file: %v\n", err)
+			return
+		}
+		fmt.Printf("File uploaded successfully: %s -> s3://%s/%s\n", filePath, bucket, key)
+	},
+}
+
 var downloadCmd = &cobra.Command{
 	Use:   "download [zs://bucket/prefix/object] [output-path]",
-	Short: "Download a file from cloud storage",
+	Short: "Download a file with erasure coding reconstruction",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		zsURL, outputPath := args[0], args[1]
@@ -88,16 +138,10 @@ var downloadCmd = &cobra.Command{
 		}
 
 		quiet, _ := cmd.Flags().GetBool("quiet")
-		noErasureCoding, _ := cmd.Flags().GetBool("no-erasure-coding")
 		concurrency, _ := cmd.Flags().GetInt("concurrency")
 
-		var reader io.ReadCloser
-		if noErasureCoding {
-			reader, err = rawFileService.DownloadFileRaw(context.Background(), key, quiet)
-		} else {
-			fileService.SetConcurrency(concurrency)
-			reader, err = fileService.DownloadFile(context.Background(), key, quiet)
-		}
+		fileService.SetConcurrency(concurrency)
+		reader, err := fileService.DownloadFile(context.Background(), key, quiet)
 		if err != nil {
 			fmt.Printf("Error downloading file: %v\n", err)
 			return
@@ -130,6 +174,57 @@ var downloadCmd = &cobra.Command{
 		}
 
 		fmt.Printf("File downloaded successfully: %s -> %s\n", key, outputPath)
+	},
+}
+
+var downloadRawCmd = &cobra.Command{
+	Use:   "download-raw [s3://bucket/prefix/object] [output-path]",
+	Short: "Download a file directly without erasure coding reconstruction",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		s3URL, outputPath := args[0], args[1]
+
+		// Parse s3:// URL to extract bucket and key
+		bucket, key, err := parseS3URL(s3URL)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		reader, err := rawFileService.DownloadFileRaw(context.Background(), bucket, key, quiet)
+		if err != nil {
+			fmt.Printf("Error downloading file: %v\n", err)
+			return
+		}
+		defer reader.Close()
+
+		// If output path is a directory, use the filename from the key
+		if stat, err := os.Stat(outputPath); err == nil && stat.IsDir() {
+			fileName := filepath.Base(key)
+			outputPath = filepath.Join(outputPath, fileName)
+		}
+
+		// Create output directory if it doesn't exist
+		if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+			fmt.Printf("Error creating output directory: %v\n", err)
+			return
+		}
+
+		outFile, err := os.Create(outputPath)
+		if err != nil {
+			fmt.Printf("Error creating output file: %v\n", err)
+			return
+		}
+		defer outFile.Close()
+
+		_, err = io.Copy(outFile, reader)
+		if err != nil {
+			fmt.Printf("Error writing file: %v\n", err)
+			return
+		}
+
+		fmt.Printf("File downloaded successfully: s3://%s/%s -> %s\n", bucket, key, outputPath)
 	},
 }
 
@@ -196,12 +291,14 @@ func init() {
 	uploadCmd.Flags().Int("data-shards", 4, "Number of data shards for erasure coding")
 	uploadCmd.Flags().Int("parity-shards", 2, "Number of parity shards for erasure coding")
 	uploadCmd.Flags().Int("concurrency", 3, "Number of concurrent shard uploads")
-	uploadCmd.Flags().Bool("no-erasure-coding", false, "Upload file directly without erasure coding")
+	uploadRawCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress progress bars")
 	downloadCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress progress bars")
 	downloadCmd.Flags().Int("concurrency", 3, "Number of concurrent shard downloads")
-	downloadCmd.Flags().Bool("no-erasure-coding", false, "Download file directly without erasure coding reconstruction")
+	downloadRawCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Suppress progress bars")
 	rootCmd.AddCommand(uploadCmd)
+	rootCmd.AddCommand(uploadRawCmd)
 	rootCmd.AddCommand(downloadCmd)
+	rootCmd.AddCommand(downloadRawCmd)
 	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(listCmd)
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16,3 +16,5 @@
 - [x] **Make download concurrent** for improved performance with configurable concurrency
 - [x] **Remove S3 references** from code comments and flags since the system now supports multiple providers
 - [x] **Auto-detect filename**: If destination filename is not specified, use the source filename
+- [x] **Add support for multiple storage prefixes**: Implemented s3:// support for raw operations via upload-raw/download-raw commands
+- [ ] **Add support for GCS and Azure**: Extend raw operations beyond S3 to support gs://, azure://, etc.


### PR DESCRIPTION
## Summary

This PR implements separate `upload-raw` and `download-raw` commands to replace the complex `--no-erasure-coding` flag approach, providing a cleaner and more intuitive CLI interface.

## Changes

### New Commands
- **`upload-raw`**: Direct S3 uploads using `s3://bucket/path` syntax
- **`download-raw`**: Direct S3 downloads using `s3://bucket/path` syntax

### Progress Bar Support
- Upload progress with file size detection via `io.Seeker`
- Download progress using S3 `HeadObject` for size determination
- `--quiet` flag support to suppress progress indicators
- Graceful fallback when size detection fails

### Architecture Improvements
- Simplified RawFileService using direct AWS SDK calls instead of factory pattern
- Removed complex flag validation logic
- Better separation of concerns between erasure-coded and raw operations

### Breaking Changes
- Removed `--no-erasure-coding` and `--raw-bucket` flags
- Raw operations now require separate commands with `s3://` URLs

## Usage Examples

```bash
# Upload raw file with progress
./zstore upload-raw /path/to/file.txt s3://my-bucket/path/file.txt

# Upload raw file quietly
./zstore upload-raw /path/to/file.txt s3://my-bucket/path/file.txt --quiet

# Download raw file with progress
./zstore download-raw s3://my-bucket/path/file.txt /path/to/output.txt

# Download raw file quietly
./zstore download-raw s3://my-bucket/path/file.txt /path/to/output.txt --quiet
```

## Testing
- Updated documentation with new command examples
- Cleaned up obsolete multi-bucket branch
- Fixed pointer receiver issues with progressbar integration

Resolves the need for simpler raw file operations while maintaining feature parity with erasure-coded operations for progress indication.