### PR TITLE
feat: implement per-bucket region configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Create a `config.yaml` file:
 log_level: info
 dynamodb_table: object_metadata
 
+# AWS region (required for S3 and DynamoDB)
+# Can also be set via AWS_REGION or AWS_DEFAULT_REGION environment variables
+aws_region: us-east-1
+
 # Multi-bucket configuration
 buckets:
   primary:
@@ -147,6 +151,10 @@ The `config.yaml` file supports:
 ```yaml
 # Logging level (debug, info, warn, error)
 log_level: info
+
+# AWS region (required for S3 and DynamoDB)
+# Priority: config.yaml > AWS_REGION env > AWS_DEFAULT_REGION env
+aws_region: us-east-1
 
 # DynamoDB table for metadata storage
 dynamodb_table: object_metadata

--- a/README.md
+++ b/README.md
@@ -13,18 +13,20 @@ Create a `config.yaml` file:
 log_level: info
 dynamodb_table: object_metadata
 
-# AWS region (required for S3 and DynamoDB)
+# DynamoDB region (required)
 # Can also be set via AWS_REGION or AWS_DEFAULT_REGION environment variables
-aws_region: us-east-1
+dynamodb_region: us-east-1
 
-# Multi-bucket configuration
+# Multi-bucket configuration with per-bucket regions
 buckets:
   primary:
     bucket_name: my-gcs-bucket
     platform: gcs
+    # region not needed for GCS
   secondary:
     bucket_name: my-s3-bucket
     platform: s3
+    region: us-west-2  # Required for S3 buckets
 ```
 
 ### 2. Environment Setup
@@ -69,11 +71,14 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 **Upload Raw Files (without erasure coding)**
 ```bash
-# Upload without erasure coding (raw file)
-./zstore upload-raw /path/to/file.txt s3://my-bucket/path/file.txt
+# Upload without erasure coding (raw file) - region required for S3
+./zstore upload-raw /path/to/file.txt s3://my-bucket/path/file.txt --region us-west-2
+
+# Upload raw file to GCS (no region needed)
+./zstore upload-raw /path/to/file.txt gs://my-bucket/path/file.txt
 
 # Upload raw file in quiet mode
-./zstore upload-raw /path/to/file.txt s3://my-bucket/path/file.txt --quiet
+./zstore upload-raw /path/to/file.txt s3://my-bucket/path/file.txt --region us-west-2 --quiet
 ```
 
 #### Download Commands
@@ -92,11 +97,14 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 **Download Raw Files (without erasure coding)**
 ```bash
-# Download without erasure coding (raw file)
-./zstore download-raw s3://my-bucket/path/file.txt /path/to/output.txt
+# Download without erasure coding (raw file) - region required for S3
+./zstore download-raw s3://my-bucket/path/file.txt /path/to/output.txt --region us-west-2
+
+# Download raw file from GCS (no region needed)
+./zstore download-raw gs://my-bucket/path/file.txt /path/to/output.txt
 
 # Download raw file in quiet mode
-./zstore download-raw s3://my-bucket/path/file.txt /path/to/output.txt --quiet
+./zstore download-raw s3://my-bucket/path/file.txt /path/to/output.txt --region us-west-2 --quiet
 ```
 
 #### Delete Commands
@@ -109,8 +117,11 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 
 **Delete Raw Files**
 ```bash
-# Delete a raw file
-./zstore delete-raw s3://my-bucket/path/file.txt
+# Delete a raw file from S3 - region required
+./zstore delete-raw s3://my-bucket/path/file.txt --region us-west-2
+
+# Delete a raw file from GCS (no region needed)
+./zstore delete-raw gs://my-bucket/path/file.txt
 ```
 
 #### List Commands
@@ -138,9 +149,9 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 - `--verify-integrity`: Enable CRC64 hash verification of downloaded shards (default: false)
 
 ### Raw Operations
-- `upload-raw`: Upload files directly to S3 without erasure coding (uses s3:// URLs, supports --quiet)
-- `download-raw`: Download files directly from S3 without erasure coding (uses s3:// URLs, supports --quiet)
-- `delete-raw`: Delete files directly from S3 without erasure coding (uses s3:// URLs)
+- `upload-raw`: Upload files directly to S3/GCS without erasure coding (uses s3:// or gs:// URLs, --region required for S3)
+- `download-raw`: Download files directly from S3/GCS without erasure coding (uses s3:// or gs:// URLs, --region required for S3)
+- `delete-raw`: Delete files directly from S3/GCS without erasure coding (uses s3:// or gs:// URLs, --region required for S3)
 
 ## Configuration
 
@@ -152,9 +163,9 @@ The `config.yaml` file supports:
 # Logging level (debug, info, warn, error)
 log_level: info
 
-# AWS region (required for S3 and DynamoDB)
+# DynamoDB region (required)
 # Priority: config.yaml > AWS_REGION env > AWS_DEFAULT_REGION env
-aws_region: us-east-1
+dynamodb_region: us-east-1
 
 # DynamoDB table for metadata storage
 dynamodb_table: object_metadata
@@ -163,10 +174,12 @@ dynamodb_table: object_metadata
 buckets:
   bucket_key_1:
     bucket_name: actual-bucket-name
-    platform: s3  # or gcs
+    platform: s3
+    region: us-west-2  # Required for S3 buckets
   bucket_key_2:
     bucket_name: another-bucket
     platform: gcs
+    # region not needed for GCS
 ```
 
 ### Supported Platforms

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,12 +56,13 @@ var debugCmd = &cobra.Command{
 		fmt.Printf("Configuration:\n")
 		fmt.Printf("  Log Level: %s\n", cfg.LogLevel)
 		fmt.Printf("  DynamoDB Table: %s\n", cfg.DynamoDBTable)
-		fmt.Printf("  AWS Region: %s\n", cfg.AwsConfig.Region)
+		fmt.Printf("  DynamoDB Region: %s\n", cfg.DynamoDBRegion)
 		fmt.Printf("\nBuckets:\n")
 		for key, bucket := range cfg.Buckets {
 			fmt.Printf("  %s:\n", key)
 			fmt.Printf("    Name: %s\n", bucket.BucketName)
 			fmt.Printf("    Platform: %s\n", bucket.Platform)
+			fmt.Printf("    Region: %s\n", bucket.Region)
 		}
 	},
 }
@@ -150,8 +151,9 @@ func initRepositories(awsConfig aws.Config, gcsClient *storage.Client, buckets m
 func createRepository(factory *objectstore.ObjectRepositoryFactory, bucketKey string, bucketConfig config.BucketConfig) objectstore.ObjectRepository {
 	// Convert config format to factory format
 	repoConfig := objectstore.BucketConfig{
-		Name: bucketConfig.BucketName,
-		Type: objectstore.RepositoryType(bucketConfig.Platform), // "s3" or "gcs"
+		Name:   bucketConfig.BucketName,
+		Type:   objectstore.RepositoryType(bucketConfig.Platform), // "s3" or "gcs"
+		Region: bucketConfig.Region,
 	}
 
 	// Use factory to create appropriate repository (S3 or GCS)

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -12,8 +12,8 @@ var (
 	ErrInsufficientShards    = errors.New("insufficient shards available for reconstruction")
 	ErrEmptyFile             = errors.New("cannot upload empty file")
 	ErrFileIntegrityCheck    = errors.New("file integrity check failed")
-	ErrAWSRegionNotConfigured = errors.New(`AWS region not configured. Please set region using one of:
-1. config.yaml: aws_region: us-east-1
+	ErrAWSRegionNotConfigured = errors.New(`DynamoDB region not configured. Please set region using one of:
+1. config.yaml: dynamodb_region: us-east-1
 2. Environment: export AWS_REGION=us-east-1
 3. Environment: export AWS_DEFAULT_REGION=us-east-1
 

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -12,6 +12,12 @@ var (
 	ErrInsufficientShards    = errors.New("insufficient shards available for reconstruction")
 	ErrEmptyFile             = errors.New("cannot upload empty file")
 	ErrFileIntegrityCheck    = errors.New("file integrity check failed")
+	ErrAWSRegionNotConfigured = errors.New(`AWS region not configured. Please set region using one of:
+1. config.yaml: aws_region: us-east-1
+2. Environment: export AWS_REGION=us-east-1
+3. Environment: export AWS_DEFAULT_REGION=us-east-1
+
+Common regions: us-east-1, us-west-2, eu-west-1, ap-southeast-1`)
 )
 
 // FetchingResourceError generates a formatted error for failed fetching of any resource by its type.

--- a/internal/service/raw_file_service.go
+++ b/internal/service/raw_file_service.go
@@ -38,11 +38,11 @@ func NewRawFileService(factory *objectstore.ObjectRepositoryFactory) *RawFileSer
 }
 
 // UploadToRepository uploads a file directly to a repository without erasure coding
-func (r *RawFileService) UploadToRepository(ctx context.Context, bucketName, key string, reader io.Reader, quiet bool, providerType objectstore.RepositoryType) error {
+func (r *RawFileService) UploadToRepository(ctx context.Context, bucketName, key string, reader io.Reader, quiet bool, providerType objectstore.RepositoryType, region string) error {
 	log.Debugf("Uploading raw file %s to bucket %s", key, bucketName)
 
-	// Create repository for this bucket with specified provider type
-	repo, err := r.createRepositoryForBucket(bucketName, providerType)
+	// Create repository for this bucket with specified provider type and region
+	repo, err := r.createRepositoryForBucket(bucketName, providerType, region)
 	if err != nil {
 		return err
 	}
@@ -52,11 +52,11 @@ func (r *RawFileService) UploadToRepository(ctx context.Context, bucketName, key
 }
 
 // DownloadFromRepository downloads a file directly from a repository without erasure coding
-func (r *RawFileService) DownloadFromRepository(ctx context.Context, bucketName, key string, dest io.WriterAt, quiet bool, providerType objectstore.RepositoryType) error {
+func (r *RawFileService) DownloadFromRepository(ctx context.Context, bucketName, key string, dest io.WriterAt, quiet bool, providerType objectstore.RepositoryType, region string) error {
 	log.Debugf("Downloading raw file %s from bucket %s", key, bucketName)
 
-	// Create repository for this bucket with specified provider type
-	repo, err := r.createRepositoryForBucket(bucketName, providerType)
+	// Create repository for this bucket with specified provider type and region
+	repo, err := r.createRepositoryForBucket(bucketName, providerType, region)
 	if err != nil {
 		return err
 	}
@@ -65,11 +65,11 @@ func (r *RawFileService) DownloadFromRepository(ctx context.Context, bucketName,
 }
 
 // DeleteFromRepository deletes a file directly from a repository without erasure coding
-func (r *RawFileService) DeleteFromRepository(ctx context.Context, bucketName, key string, providerType objectstore.RepositoryType) error {
+func (r *RawFileService) DeleteFromRepository(ctx context.Context, bucketName, key string, providerType objectstore.RepositoryType, region string) error {
 	log.Debugf("Deleting raw file %s from bucket %s", key, bucketName)
 
-	// Create repository for this bucket with specified provider type
-	repo, err := r.createRepositoryForBucket(bucketName, providerType)
+	// Create repository for this bucket with specified provider type and region
+	repo, err := r.createRepositoryForBucket(bucketName, providerType, region)
 	if err != nil {
 		return err
 	}
@@ -77,11 +77,12 @@ func (r *RawFileService) DeleteFromRepository(ctx context.Context, bucketName, k
 	return repo.Delete(ctx, key)
 }
 
-// createRepositoryForBucket creates a repository based on bucket name and provider type
-func (r *RawFileService) createRepositoryForBucket(bucketName string, providerType objectstore.RepositoryType) (objectstore.ObjectRepository, error) {
+// createRepositoryForBucket creates a repository based on bucket name, provider type, and region
+func (r *RawFileService) createRepositoryForBucket(bucketName string, providerType objectstore.RepositoryType, region string) (objectstore.ObjectRepository, error) {
 	config := objectstore.BucketConfig{
-		Name: bucketName,
-		Type: providerType,
+		Name:   bucketName,
+		Type:   providerType,
+		Region: region,
 	}
 	return r.factory.CreateRepository(config)
 }

--- a/tests/service/file_service_benchmark_test.go
+++ b/tests/service/file_service_benchmark_test.go
@@ -37,8 +37,9 @@ func setupTestServices(b *testing.B) (*service.FileService, *service.RawFileServ
 
 	for bucketKey, bucketConfig := range cfg.Buckets {
 		repoConfig := objectstore.BucketConfig{
-			Name: bucketConfig.BucketName,
-			Type: objectstore.RepositoryType(bucketConfig.Platform),
+			Name:   bucketConfig.BucketName,
+			Type:   objectstore.RepositoryType(bucketConfig.Platform),
+			Region: bucketConfig.Region,
 		}
 		repo, err := factory.CreateRepository(repoConfig)
 		if err != nil {
@@ -178,12 +179,12 @@ func BenchmarkRawFileService_UploadFile(b *testing.B) {
 						key := "benchmark/raw-test-file"
 						reader := bytes.NewReader(data)
 						
-						err := rawFileService.UploadToRepository(context.Background(), bucketConfig.BucketName, key, reader, true, objectstore.RepositoryType(bucketConfig.Platform))
+						err := rawFileService.UploadToRepository(context.Background(), bucketConfig.BucketName, key, reader, true, objectstore.RepositoryType(bucketConfig.Platform), bucketConfig.Region)
 						if err != nil {
 							b.Fatalf("Raw UploadFile failed: %v", err)
 						}
 
-						rawFileService.DeleteFromRepository(context.Background(), bucketConfig.BucketName, key, objectstore.RepositoryType(bucketConfig.Platform))
+						rawFileService.DeleteFromRepository(context.Background(), bucketConfig.BucketName, key, objectstore.RepositoryType(bucketConfig.Platform), bucketConfig.Region)
 					}
 				})
 			}
@@ -217,7 +218,7 @@ func BenchmarkRawFileService_DownloadFile(b *testing.B) {
 					rand.Read(data)
 					key := "benchmark/raw-download-test-file"
 					
-					err := rawFileService.UploadToRepository(context.Background(), bucketConfig.BucketName, key, bytes.NewReader(data), true, objectstore.RepositoryType(bucketConfig.Platform))
+					err := rawFileService.UploadToRepository(context.Background(), bucketConfig.BucketName, key, bytes.NewReader(data), true, objectstore.RepositoryType(bucketConfig.Platform), bucketConfig.Region)
 					if err != nil {
 						b.Fatalf("Setup failed: %v", err)
 					}
@@ -231,7 +232,7 @@ func BenchmarkRawFileService_DownloadFile(b *testing.B) {
 						if err != nil {
 							b.Fatalf("Failed to create temp file: %v", err)
 						}
-						err = rawFileService.DownloadFromRepository(context.Background(), bucketConfig.BucketName, key, tempFile, true, objectstore.RepositoryType(bucketConfig.Platform))
+						err = rawFileService.DownloadFromRepository(context.Background(), bucketConfig.BucketName, key, tempFile, true, objectstore.RepositoryType(bucketConfig.Platform), bucketConfig.Region)
 						tempFile.Close()
 						os.Remove(tempFile.Name())
 						if err != nil {
@@ -239,7 +240,7 @@ func BenchmarkRawFileService_DownloadFile(b *testing.B) {
 						}
 					}
 
-					rawFileService.DeleteFromRepository(context.Background(), bucketConfig.BucketName, key, objectstore.RepositoryType(bucketConfig.Platform))
+					rawFileService.DeleteFromRepository(context.Background(), bucketConfig.BucketName, key, objectstore.RepositoryType(bucketConfig.Platform), bucketConfig.Region)
 				})
 			}
 		})
@@ -262,12 +263,12 @@ func BenchmarkRawFileService_CrossProvider_Comparison(b *testing.B) {
 				key := "benchmark/cross-provider-test"
 				reader := bytes.NewReader(data)
 				
-				err := rawFileService.UploadToRepository(context.Background(), bucketConfig.BucketName, key, reader, true, objectstore.RepositoryType(bucketConfig.Platform))
+				err := rawFileService.UploadToRepository(context.Background(), bucketConfig.BucketName, key, reader, true, objectstore.RepositoryType(bucketConfig.Platform), bucketConfig.Region)
 				if err != nil {
 					b.Fatalf("Raw UploadFile failed: %v", err)
 				}
 
-				rawFileService.DeleteFromRepository(context.Background(), bucketConfig.BucketName, key, objectstore.RepositoryType(bucketConfig.Platform))
+				rawFileService.DeleteFromRepository(context.Background(), bucketConfig.BucketName, key, objectstore.RepositoryType(bucketConfig.Platform), bucketConfig.Region)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Implements per-bucket region configuration to handle the edge case where S3 buckets and DynamoDB can be in different AWS regions.

## Changes
- Replace `aws_region` with `dynamodb_region` for DynamoDB
- Add required `region` field to BucketConfig for S3 buckets
- Implement per-region S3 client caching in ObjectRepositoryFactory
- Add `--region` flag to all raw commands (upload-raw, download-raw, delete-raw)
- Validate region is provided for S3 operations
- Update RawFileService to accept region parameter
- Update README with region configuration examples
- Fix benchmark tests

## Breaking Changes
- **config.yaml**: `aws_region` renamed to `dynamodb_region`
- **config.yaml**: `region` field now required for S3 buckets
- **Raw commands**: `--region` flag now required for S3 operations

## Example Configuration
```yaml
dynamodb_region: us-east-1

buckets:
  primary:
    bucket_name: my-s3-bucket
    platform: s3
    region: us-west-2  # Required for S3
  secondary:
    bucket_name: my-gcs-bucket
    platform: gcs
    # region not needed for GCS
```

## Testing
- Updated benchmark tests to pass region parameter
- All raw operations now validate region for S3